### PR TITLE
Fixed NPE without useful message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.glassfish.build</groupId>
     <artifactId>command-security-maven-plugin</artifactId>
-    <version>1.0.17-SNAPSHOT-SNAPSHOT</version>
+    <version>1.0.17-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Command Security Plug-in</name>
@@ -122,7 +122,7 @@
                         <target>11</target>
                     </configuration>
                 </plugin>
-            
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
@@ -134,12 +134,12 @@
                         <execution>
                             <id>attach-sources</id>
                             <goals>
-                                <goal>jar-no-fork</goal> 
+                                <goal>jar-no-fork</goal>
                             </goals>
                         </execution>
                     </executions>
                 </plugin>
-                
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
@@ -158,7 +158,7 @@
                         </execution>
                     </executions>
                 </plugin>
-                
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>

--- a/src/main/java/org/glassfish/module/maven/commandsecurityplugin/TypeAnalyzer.java
+++ b/src/main/java/org/glassfish/module/maven/commandsecurityplugin/TypeAnalyzer.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.objectweb.asm.*;
 
 /**
@@ -858,6 +859,7 @@ public class TypeAnalyzer {
         public void visitEnd() {
             final String dottedTypeName = fieldScanner.fullFriendlyTypeName().replace("/", ".");
             TypeProcessorImpl.Inhabitant i = typeProcessor.configBeans().get(dottedTypeName);
+            Objects.requireNonNull(i, "The inhabitant found for this type was null: " + dottedTypeName);
             for (String action : actions) {
                 authInfo.addResourceAction(i.fullPath() + (! collection.isEmpty() ? "/" : "") + collection + "/$xxx", action, "@AccessRequired.To");
             }


### PR DESCRIPTION
Now it gives at least some info.
Reproduced when I broke glassfishbuild maven plugin and config-generator ;-)

Now it prints this:

```
[ERROR] Failed to execute goal org.glassfish.build:command-security-maven-plugin:1.0.17-SNAPSHOT:check
(default-check) on project security: Error analyzing com.sun.enterprise.security.cli.ChangeAdminPassword: 
The inhabitant found for this type was null: com.sun.enterprise.config.serverbeans.AuthRealm
```