### PR TITLE
Use `:helpmojo` to generate `:help` goal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation
     Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -166,6 +166,18 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>helpmojo</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
 </project>


### PR DESCRIPTION
Replace
```
[ERROR] Could not find goal 'help' in plugin org.glassfish.build:command-security-maven-plugin:1.0.20-SNAPSHOT among available goals check, print -> [Help 1]
```
with
```
[INFO] --- command-security:1.0.20-SNAPSHOT:help (default-cli) @ command-security-maven-plugin ---
[INFO] Command Security Plug-in 1.0.20-SNAPSHOT
  Maven plug-in for checking that AdminCommand implementers address command
  authorization

This plugin has 3 goals:

command-security:check
  Verifies that all inhabitants in the module that are commands also take care
  ...

command-security:help
  Display help information on command-security-maven-plugin.
  ...

command-security:print
  Displays a concise summary of each command found at the current level in the
  ...
```